### PR TITLE
Add SetLevel() to DefaultLeveledLogger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -94,6 +94,11 @@ func (ll *DefaultLeveledLogger) logf(logger *log.Logger, level LogLevel, format 
 	}
 }
 
+// SetLevel sets the logger's logging level
+func (ll *DefaultLeveledLogger) SetLevel(newLevel LogLevel) {
+	ll.level.Set(newLevel)
+}
+
 // Trace emits the preformatted message if the logger is at or below LogLevelTrace
 func (ll *DefaultLeveledLogger) Trace(msg string) {
 	ll.logf(ll.trace, LogLevelTrace, msg)

--- a/logging_test.go
+++ b/logging_test.go
@@ -103,3 +103,12 @@ func TestDefaultLogger(t *testing.T) {
 	testWarnLevel(t, logger)
 	testErrorLevel(t, logger)
 }
+
+func TestSetLevel(t *testing.T) {
+	logger := logging.
+		NewDefaultLeveledLoggerForScope("testSetLevel", logging.LogLevelWarn, os.Stdout)
+
+	testNoDebugLevel(t, logger)
+	logger.SetLevel(logging.LogLevelDebug)
+	testDebugLevel(t, logger)
+}


### PR DESCRIPTION
Also updates DefaultLeveledLogger implementation to conform. Allows
a custom LoggerFactory to update a logger's loglevel at runtime.
